### PR TITLE
Обновление django-haystack-1.2.7 до 2.1.0

### DIFF
--- a/reqs/base.txt
+++ b/reqs/base.txt
@@ -3,7 +3,7 @@ Django==1.4.9
 django-admin-tools==0.5.1
 django-autoslug-field==0.2.3
 django-extensions==1.2.2
-django-haystack==1.2.7
+django-haystack==2.1.0
 django-model-utils==1.0.0
 django-modeltranslation
 django-pagedown==0.0.5
@@ -22,8 +22,8 @@ python_openid==2.2.5
 pytils==0.2.3
 pytz
 sorl-thumbnail==11.12
-xapian-haystack==1.1.5beta
 -e git+git://github.com/RaD/django-chunks.git@rel2.7#egg=django-chunks
 -e git+http://github.com/clintecker/django-google-analytics.git/#egg=django-google_analytics
 -e git+https://github.com/RaD/haystack-static-pages.git/#egg=haystack-static-pages
 -e hg+https://bitbucket.org/ruslanpopov/django-sentry#egg=sentry
+-e git+https://github.com/benjaoming/xapian-haystack.git/#egg=xapian-haystack

--- a/src/examples/search_indexes.py
+++ b/src/examples/search_indexes.py
@@ -1,15 +1,14 @@
 # -*- coding: utf-8 -*-
 
-from haystack.indexes import *
-from haystack import site
-
-from . import models
+from haystack import indexes
+from .models import Example
 
 
-class ExampleIndex(SearchIndex):
-    text = CharField(document=True, use_template=True)
-    title = CharField(model_attr='title')
-    created = DateTimeField(model_attr='created')
-    author = CharField(model_attr='author')
-
-site.register(models.Example, ExampleIndex)
+class ExampleIndex(indexes.SearchIndex, indexes.Indexable):
+    text = indexes.CharField(document=True, use_template=True)
+    title = indexes.CharField(model_attr='title')
+    created = indexes.DateTimeField(model_attr='created')
+    author = indexes.CharField(model_attr='author')
+    
+    def get_model(self):
+        return Example

--- a/src/forum/search_indexes.py
+++ b/src/forum/search_indexes.py
@@ -1,20 +1,19 @@
 # encoding: utf-8
 
-from haystack.indexes import *
-from haystack import site
-
+from haystack import indexes
 from .models import Topic
 
 
-class TopicIndex(SearchIndex):
-    text = CharField(document=True, use_template=True)
-    author = CharField(model_attr='user')
-    created = DateTimeField(model_attr='created')
-    name = CharField(model_attr='name')
-    category = CharField(model_attr='forum__category__name')
-    forum = IntegerField(model_attr='forum__pk')
+class TopicIndex(indexes.SearchIndex, indexes.Indexable):
+    text = indexes.CharField(document=True, use_template=True)
+    author = indexes.CharField(model_attr='user')
+    created = indexes.DateTimeField(model_attr='created')
+    name = indexes.CharField(model_attr='name')
+    category = indexes.CharField(model_attr='forum__category__name')
+    forum = indexes.IntegerField(model_attr='forum__pk')
 
-    def index_queryset(self):
-        return Topic.objects.filter(forum__category__groups=None)
+    def get_model(self):
+        return Topic
 
-site.register(Topic, TopicIndex)
+    def get_queryset(self, using=None):
+        return self.get_model().objects.filter(forum__category__groups=None)

--- a/src/news/search_indexes.py
+++ b/src/news/search_indexes.py
@@ -1,14 +1,14 @@
 # -*- coding: utf-8 -*-
 
-from haystack.indexes import *
-from haystack import site
+from haystack import indexes
 from django.utils.translation import ugettext_lazy as _
-from . import models
+from .models import News
 
 
-class NewsIndex(SearchIndex):
-    text = CharField(document=True, use_template=True)
-    title = CharField(model_attr='title')
-    created = DateTimeField(model_attr='created')
-
-site.register(models.News, NewsIndex)
+class NewsIndex(indexes.SearchIndex, indexes.Indexable):
+    text = indexes.CharField(document=True, use_template=True)
+    title = indexes.CharField(model_attr='title')
+    created = indexes.DateTimeField(model_attr='created')
+    
+    def get_model(self):
+        return News

--- a/src/search_sites.py
+++ b/src/search_sites.py
@@ -1,2 +1,0 @@
-import haystack
-haystack.autodiscover()

--- a/src/settings.py
+++ b/src/settings.py
@@ -363,9 +363,12 @@ def get_doc_pages(path, ext):
 DJANGO_DOCUMENTATION_URL = '/rel1.5/'
 
 INSTALLED_APPS += ('haystack', 'haystack_static_pages')
-HAYSTACK_SITECONF = 'src.search_sites'
-HAYSTACK_SEARCH_ENGINE = 'xapian'
-HAYSTACK_XAPIAN_PATH = rel_project('search', 'xapian_index')
+HAYSTACK_CONNECTIONS = {
+    'default': {
+        'ENGINE': 'xapian_backend.XapianEngine',
+        'PATH': rel_project('search', 'xapian_index'),
+    }
+}
 HAYSTACK_STATIC_PAGES = tuple(
     get_doc_pages(
         os.path.expanduser('~/devel/django_documentation/_build/html'),

--- a/src/urls.py
+++ b/src/urls.py
@@ -5,13 +5,10 @@ from django.conf.urls.defaults import patterns, include, url
 from django.contrib import admin
 from django.contrib.staticfiles.urls import staticfiles_urlpatterns
 
-from haystack import autodiscover as haystack_autodiscover
-
 from patch import sites_flatpages_patch
 from src.main import feeds
 from src.utils.views import direct_to_template
 
-haystack_autodiscover()
 admin.autodiscover()
 sites_flatpages_patch()
 


### PR DESCRIPTION
#225
- xapian-haystack ставится через git, потому что в PyPi старая версия.
- Удалён параметр HAYSTACK_SITECONF и файл search_sites.py
- Удалён autodiscover в urls.py
- search_indexes.py изменены

P.S. Для работы сайта требуется аналогичное обновление django-sentry и haystack-static-page.
