### PR TITLE
DisallowedHost error. Allow access from 127.0.0.1

### DIFF
--- a/src/local_settings.py.dev.template
+++ b/src/local_settings.py.dev.template
@@ -8,6 +8,7 @@ TEMPLATE_DEBUG = True
 
 ADMINS = (
 )
+ALLOWED_HOSTS = ('127.0.0.1',)
 
 DATABASES = {
     'default': dict(


### PR DESCRIPTION
```
Starting development server at http://127.0.0.1:8000/
```
When user opens this url he gets:
```
DisallowedHost: Invalid HTTP_HOST header: '127.0.0.1:8000'. You may need to add u'127.0.0.1' to ALLOWED_HOSTS.
```